### PR TITLE
Override TextInput placeholder color

### DIFF
--- a/frontend/+mobile/DashboardForm.qml
+++ b/frontend/+mobile/DashboardForm.qml
@@ -134,7 +134,6 @@ Item {
         font.pixelSize: 36
         font.family: "Brandon Grotesque"
         color: "#E5E5E5"
-
     }
 
     Switch {
@@ -152,7 +151,6 @@ Item {
             origin.y: 25
             angle: 90
         }
-
     }
     /**
     Label {
@@ -1027,7 +1025,8 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
         anchors.topMargin: 150
-        visible: transferTracker == 1 && addressBookTracker != 1 && scanQRCodeTracker != 1
+        visible: transferTracker == 1 && addressBookTracker != 1
+                 && scanQRCodeTracker != 1
         radius: 4
         z: 100
 
@@ -1168,7 +1167,7 @@ Item {
                 foreground: "black"
             }
         }
-        Rectangle{
+        Rectangle {
             id: qrBorder
             radius: 8
             width: 210
@@ -1234,7 +1233,7 @@ Item {
             id: sendAmount
             height: 34
             //radius: 8
-            placeholderText: "AMOUNT (XBY)"
+            placeholder: "AMOUNT (XBY)"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: currencyIcon.bottom
             anchors.topMargin: 15
@@ -1247,7 +1246,7 @@ Item {
         Controls.TextInput {
             id: keyInput
             height: 34
-            placeholderText: "SEND TO (PUBLIC KEY)"
+            placeholder: "SEND TO (PUBLIC KEY)"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: sendAmount.bottom
             anchors.topMargin: 15
@@ -1318,7 +1317,7 @@ Item {
             id: referenceInput
             height: 34
             // radius: 8
-            placeholderText: "REFERENCE"
+            placeholder: "REFERENCE"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: scanQrButton.bottom
             anchors.topMargin: 15
@@ -1448,7 +1447,7 @@ Item {
             anchors.verticalCenter: addressIconName.verticalCenter
         }
 
-        Rectangle{
+        Rectangle {
             id: seperator1
             color: "#575757"
             height: 1
@@ -1489,11 +1488,13 @@ Item {
             MouseArea {
                 anchors.fill: transferChoice1
                 onClicked: {
+
+
                     //transferTracker = 1
                 }
             }
         }
-        Rectangle{
+        Rectangle {
             id: seperator2
             color: "#575757"
             height: 1
@@ -1534,11 +1535,13 @@ Item {
             MouseArea {
                 anchors.fill: transferChoice2
                 onClicked: {
+
+
                     //transferTracker = 1
                 }
             }
         }
-        Rectangle{
+        Rectangle {
             id: seperator3
             color: "#575757"
             height: 1
@@ -1579,11 +1582,13 @@ Item {
             MouseArea {
                 anchors.fill: transferChoice3
                 onClicked: {
+
+
                     //transferTracker = 1
                 }
             }
         }
-        Rectangle{
+        Rectangle {
             id: seperator4
             color: "#575757"
             height: 1
@@ -1628,7 +1633,7 @@ Item {
                 }
             }
         }
-        Rectangle{
+        Rectangle {
             id: seperator5
             color: "#575757"
             height: 1
@@ -1669,6 +1674,8 @@ Item {
             MouseArea {
                 anchors.fill: transferChoice5
                 onClicked: {
+
+
                     //transferTracker = 1
                 }
             }

--- a/frontend/Controls/TextInput.qml
+++ b/frontend/Controls/TextInput.qml
@@ -11,7 +11,6 @@
  */
 import QtQuick 2.7
 import QtQuick.Controls 2.2
-import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 
 import "../Theme" 1.0

--- a/frontend/Controls/TextInput.qml
+++ b/frontend/Controls/TextInput.qml
@@ -10,13 +10,14 @@
  *
  */
 import QtQuick 2.7
-import QtQuick.Controls 2.3
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Styles 1.4
 import QtQuick.Layouts 1.3
 
 import "../Theme" 1.0
 
 TextField {
-    id: component
+    id: textInputComponent
     color: "white"
     font.weight: Font.Light
     font.pixelSize: 24
@@ -26,7 +27,6 @@ TextField {
     bottomPadding: 10
     verticalAlignment: Text.AlignVCenter
     selectByMouse: true
-
     background: Rectangle {
         color: "#2A2C31"
         radius: 4
@@ -34,10 +34,29 @@ TextField {
         border.color: Theme.secondaryHighlight
         implicitWidth: 273
     }
-
     onActiveFocusChanged: {
-        if (component.focus) {
+        if (textInputComponent.focus) {
             EventFilter.focus(this)
         }
+    }
+
+    property alias placeholder: placeholderTextComponent.text
+
+    Text {
+        id: placeholderTextComponent
+        anchors.fill: textInputComponent
+        font: textInputComponent.font
+        horizontalAlignment: textInputComponent.horizontalAlignment
+        verticalAlignment: textInputComponent.verticalAlignment
+        leftPadding: textInputComponent.leftPadding
+        rightPadding: textInputComponent.rightPadding
+        topPadding: textInputComponent.topPadding
+        bottomPadding: textInputComponent.bottomPadding
+        opacity: !textInputComponent.displayText
+                 && (!textInputComponent.activeFocus
+                     || textInputComponent.horizontalAlignment !== Qt.AlignHCenter) ? 1.0 : 0.0
+        color: textInputComponent.color
+        clip: contentWidth > width
+        elide: Text.ElideRight
     }
 }


### PR DESCRIPTION
Some test devices display `TextField` placeholder in a black color instead of the `TextField`'s color. Since we're using Qt Controls 2 which doesn't support the "style" property necessary to set text color, this PR adds a custom placeholder component to the `TextInput.qml` control. The color is aliased to the `TextField`'s color.

The new component's placeholder value is aliased to a new `placeholder` property, whereas the native `TextField` placeholder value property is `placeholderText`. Since the root object in the `TextField.qml` control is `TextField` and not `Item`, both properties will be visible when implementing `TextInput.qml`.

To avoid placeholder color issues after this PR is in place, always use the `placeholder` property when implementing `TextInput.qml`.